### PR TITLE
Fixed missing end tag error

### DIFF
--- a/docs/UCV/ucv-ext-jira/jiraCustom.md
+++ b/docs/UCV/ucv-ext-jira/jiraCustom.md
@@ -163,7 +163,7 @@ json
 Advanced value mapping supports complex conditional logic using:
 * **Objects {}**: Act as AND operators (all conditions must match)
 * **Arrays []**: Act as OR operators (any condition can match)
-* **Regex patterns**: Match text patterns using **/<pattern>/** syntax
+* **Regex patterns**: Match text patterns using `/<pattern>/` syntax
 
 # Example 1: Conditional Mapping with Description Pattern
 


### PR DESCRIPTION
@leelavathidh @madhavbk the vitepress build process failed
https://github.com/UrbanCode/IBM-UCx-PLUGIN-DOCS/actions/runs/18397714654/job/52420197869

With below error
<img width="1391" height="611" alt="image" src="https://github.com/user-attachments/assets/b871b0c3-aa33-4e67-a0fd-fc6f52529981" />

We have to escape anything within `<` and `>` with the symbol (`)