### PR TITLE
DevOps Deploy Versions - Updated v77 and v78

### DIFF
--- a/docs/UCD/uDeploy-Version/downloads.md
+++ b/docs/UCD/uDeploy-Version/downloads.md
@@ -2,8 +2,8 @@
 # IBM DevOps Deploy Versions - Downloads
 
 To download the plug-in, click the following version-specific links.
-- [ucd-uDeploy-Version-78.1185299.zip](https://github.com/UrbanCode/IBM-UCD-PLUGINS/raw/refs/heads/main/files/uDeploy-Version/ucd-uDeploy-Version-78.1185299.zip)
-- [ucd-uDeploy-Version-77.1179532.zip](https://github.com/UrbanCode/IBM-UCD-PLUGINS/raw/refs/heads/main/files/uDeploy-Version/ucd-uDeploy-Version-77.1179532.zip)
+- [ucd-uDeploy-Version-78.1185299.zip](https://github.com/UrbanCode/IBM-UCD-PLUGINS/raw/refs/heads/main/files/uDeploy-Version/devops-deploy-uDeploy-Version-78.1185299.zip)
+- [ucd-uDeploy-Version-77.1179532.zip](https://github.com/UrbanCode/IBM-UCD-PLUGINS/raw/refs/heads/main/files/uDeploy-Version/devops-deploy-uDeploy-Version-77.1179532.zip)
 - [ucd-uDeploy-Version-76.1176673.zip](https://github.com/UrbanCode/IBM-UCD-PLUGINS/raw/refs/heads/main/files/uDeploy-Version/ucd-uDeploy-Version-76.1176673.zip)
 - [ucd-uDeploy-Version-75.1175079.zip](https://github.com/UrbanCode/IBM-UCD-PLUGINS/raw/refs/heads/main/files/uDeploy-Version/ucd-uDeploy-Version-75.1175079.zip)
 - [ucd-uDeploy-Version-74.1155707.zip](https://github.com/UrbanCode/IBM-UCD-PLUGINS/raw/refs/heads/main/files/uDeploy-Version/ucd-uDeploy-Version-74.1155707.zip)

--- a/docs/UCD/uDeploy-Version/downloads.md
+++ b/docs/UCD/uDeploy-Version/downloads.md
@@ -2,6 +2,8 @@
 # IBM DevOps Deploy Versions - Downloads
 
 To download the plug-in, click the following version-specific links.
+- [ucd-uDeploy-Version-78.1185299.zip](https://github.com/UrbanCode/IBM-UCD-PLUGINS/raw/refs/heads/main/files/uDeploy-Version/ucd-uDeploy-Version-78.1185299.zip)
+- [ucd-uDeploy-Version-77.1179532.zip](https://github.com/UrbanCode/IBM-UCD-PLUGINS/raw/refs/heads/main/files/uDeploy-Version/ucd-uDeploy-Version-77.1179532.zip)
 - [ucd-uDeploy-Version-76.1176673.zip](https://github.com/UrbanCode/IBM-UCD-PLUGINS/raw/refs/heads/main/files/uDeploy-Version/ucd-uDeploy-Version-76.1176673.zip)
 - [ucd-uDeploy-Version-75.1175079.zip](https://github.com/UrbanCode/IBM-UCD-PLUGINS/raw/refs/heads/main/files/uDeploy-Version/ucd-uDeploy-Version-75.1175079.zip)
 - [ucd-uDeploy-Version-74.1155707.zip](https://github.com/UrbanCode/IBM-UCD-PLUGINS/raw/refs/heads/main/files/uDeploy-Version/ucd-uDeploy-Version-74.1155707.zip)

--- a/docs/UCD/uDeploy-Version/overview.md
+++ b/docs/UCD/uDeploy-Version/overview.md
@@ -15,6 +15,12 @@ No special steps are required for installation. See [Installing plug-ins in DevO
 
 ## Release Notes
 
+### Version 78
+Update Apache log4j to 2.25.3 for non-exploitable CVE-2025-68161 
+
+### Version 77
+Update commons-lang to 3.18 resolves finding for non-exploitable CVE-2025-48924
+
 ### Version 76
 Fix an issue with certain steps on z/OS
 


### PR DESCRIPTION
Updated overview and download links for v77 and v78